### PR TITLE
Potential fix for code scanning alert no. 298: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check-translations.yml
+++ b/.github/workflows/check-translations.yml
@@ -1,4 +1,6 @@
 name: check-translations
+permissions:
+  contents: read
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/avarcorg/avarc-server/security/code-scanning/298](https://github.com/avarcorg/avarc-server/security/code-scanning/298)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the minimal permissions required for the workflow to function. Based on the workflow's operations, it only needs to read the repository contents. Therefore, we will set `contents: read` as the permission.

The `permissions` block will be added after the `name` field and before the `on` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
